### PR TITLE
Only run CI on pushes to master

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -2,6 +2,8 @@ name: Haskell CI
 
 on:
   push:
+    branches:
+      - master
   pull_request:
 
 jobs:


### PR DESCRIPTION
It appears that enabling CI for all branches and all PRs causes double
runs on PRs. An example of this can be seen e.g. in #36. This commit
changes so that only direct pushes to master, as well as any PRs
(including ones that merge with other targets than master) trigger CI.