### PR TITLE
Remove superfluous transferCall ID

### DIFF
--- a/src/EvmCompiler.hs
+++ b/src/EvmCompiler.hs
@@ -26,7 +26,7 @@ module EvmCompiler where
 
 import EvmCompilerHelper
 import EvmLanguageDefinition
-import EvmCompilerSubroutines (subroutines, transferCallToSettlementAsset)
+import EvmCompilerSubroutines (subroutines, partyTokenIdToSettlementAssetId)
 import IntermediateLanguageDefinition
 import SwordLanguageDefinition hiding (Transfer)
 import IntermediateCompiler (emptyContract)
@@ -66,7 +66,7 @@ runExprCompiler env expr = runCompiler emptyContract env (compileExp expr)
 -- position value that a contract position evaluates to
 data StorageType = CreationTimestamp
                  | MemoryExpressionRefs
-                 | EvaluatedTcValue TransferCallId
+                 | EvaluatedTcValue PartyIndex
 
 -- For each storage index we pay 20000 GAS. Reusing one is only 5000 GAS.
 -- It would therefore make sense to pack as much as possible into the same index.
@@ -120,7 +120,7 @@ evmCompile intermediateContract =
   where
     constructor'       = constructor intermediateContract
     codecopy'          = codecopy constructor' body
-    dynamicSubroutines = transferCallToSettlementAsset (getTransferCalls intermediateContract)
+    dynamicSubroutines = partyTokenIdToSettlementAssetId (getTransferCalls intermediateContract)
     body               = jumpTable ++ subroutines ++ dynamicSubroutines ++ methods
 
     methods :: [EvmOpcode]
@@ -211,7 +211,7 @@ initializeEvaluatedTcValues ic =
     setToMinusOne :: TransferCall -> [EvmOpcode]
     setToMinusOne tc =
       [ DUP1
-      , push (storageAddress (EvaluatedTcValue (_tcId tc)))
+      , push (storageAddress (EvaluatedTcValue (_to tc)))
       , SSTORE
       ]
 
@@ -342,10 +342,10 @@ payABI = do
         ++ emitEvent "Paid"
         ++ [ STOP ]
 
--- For hver Transfer Call ID:
---   value := Storage[TCID];
---   j := TCs[TCID]._saAddress;
---   if (value == -1) goto end;
+-- For hver Party Token ID:
+--   value := Storage[PTID];
+--   j := TCs[PTID]._saAddress;
+--   if (value == 0) goto end;
 --   PT0_udbetaling_j += value;
 --
 -- PT0_udbetaling_j = ActivateMap_j - 
@@ -355,68 +355,65 @@ payToPartyToken0 = do
   pt0_no_pay <- newLabel "pt0_no_pay"
   -- TODO: The PT0 balance read here can be reused below, so we don't have to load it again
   let skipIfPt0BalanceIsZero = [CALLER, push 0x00, FUNCALL "getBalance_subroutine", ISZERO, JUMPITO pt0_no_pay]
-  maxTcId <- reader getMaxTcId
+  maxPtId <- reader getMaxPartyTokenId
   let subtractEvaluatedPTValuesFromSaAmounts = [
      -- Stack = [ ... ]
-          push maxTcId
-       -- loop (tc_id from maxTcId to 0)
-       -- do ... while (tc_id != 0)
+          push maxPtId
+       -- loop (ptid from maxPtId to 1), as party token IDs are 1-indexed
+       -- do ... while (ptid != 0)
        , JUMPDESTFROM begin0
-         -- Stack = [ tc_id ]
+         -- Stack = [ ptid ]
 
          -- Hack: Dynamically calculate storage address.
        , DUP1
        , push (storageAddress (EvaluatedTcValue 0))
        , ADD
        , SLOAD
-         -- Stack = [ tc_value, tc_id ]
+         -- Stack = [ tc_value, ptid ]
 
-         -- If value[tc_id] < 0, don't perform PT0 payout.
+         -- If value[ptid] < 0, don't perform PT0 payout.
        , DUP1
        , push 0x00
        , SGT
-         -- Stack = [ 0 > tc_value, tc_value, tc_id ]
+         -- Stack = [ 0 > tc_value, tc_value, ptid ]
        , JUMPITO pt0_no_pay
 
-         -- Stack = [ tc_value, tc_id ]
+         -- Stack = [ tc_value, ptid ]
          -- Load accumulated payback value onto Stack
 
        , DUP2
-         -- Stack = [ tc_id, tc_value, tc_id ]
-       , FUNCALL "transferCallToSettlementAsset_subroutine"
-      --    -- Stack = [ saId, tc_value, tc_id ]
+         -- Stack = [ ptid, tc_value, ptid ]
+       , FUNCALL "partyTokenIdToSettlementAssetId_subroutine"
+      --    -- Stack = [ saId, tc_value, ptid ]
        , push 0x20
        , MUL
        , push 0x100 -- TODO: Name this constant.
        , ADD
        , DUP1
        , MLOAD
-         -- Stack = [ M[0x100 + 0x20 * saId], 0x100 + 0x20 * saId, tc_value, tc_id ]
+         -- Stack = [ M[0x100 + 0x20 * saId], 0x100 + 0x20 * saId, tc_value, ptid ]
 
        , DUP3
        , SWAP1
-         -- Stack = [ M[0x100 +0x20 * saId], tc_value, 0x100 + 0x20 * saId, tc_value, tc_id ]
+         -- Stack = [ M[0x100 +0x20 * saId], tc_value, 0x100 + 0x20 * saId, tc_value, ptid ]
 
          -- Update and store accumulated payback value in memory
        , FUNCALL "safeSub_subroutine"
-         -- Stack = [ M[0x100 + 0x20 * saId] - tc_value, 0x100 + 0x20 * saId, tc_value, tc_id ]
+         -- Stack = [ M[0x100 + 0x20 * saId] - tc_value, 0x100 + 0x20 * saId, tc_value, ptid ]
        , SWAP1
-         -- Stack = [ 0x100 + 0x20 * saId, M[0x100 + 0x20 * saId] - tc_value, tc_value, tc_id ]
+         -- Stack = [ 0x100 + 0x20 * saId, M[0x100 + 0x20 * saId] - tc_value, tc_value, ptid ]
        , MSTORE
        , POP
-         --  Stack = [ tc_id ]
+         --  Stack = [ ptid ]
 
-      --    -- Loop condition check: if (--tc_id >= 0) goto begin0
+      --    -- Loop condition check: if (--ptid != 0) goto begin0
        , push 0x01
        , SWAP1
        , SUB
        , DUP1
-       , push 0x00
-       , SGT
-       , ISZERO
        , JUMPITO begin0
 
-       , POP ] -- tc_id removed ]
+       , POP ] -- ptid removed ]
   loadActivateAmounts <- loadActivateMapIntoMemory <$> reader getActivateMap
   performPayoutPT0 <- payBackCalculatedValueToPT0 <$> reader getActivateMap
   return $
@@ -688,32 +685,32 @@ compileLit lit mo _label = case lit of
 executeTransferCallsHH :: TransferCall -> [EvmOpcode]
 executeTransferCallsHH tc =
   let
-    begin = [ JUMPTO $ "begin_tc_evaluation" ++ show (_tcId tc)]
+    begin = [ JUMPTO $ "begin_tc_evaluation" ++ show (_to tc)]
     setTCEvaluatedValueToZero =
-      [ JUMPDESTFROM $ "set_evaluated_value_to_zero" ++ show (_tcId tc)
+      [ JUMPDESTFROM $ "set_evaluated_value_to_zero" ++ show (_to tc)
       , push 0x00
-      , push (storageAddress (EvaluatedTcValue (_tcId tc)))
+      , push (storageAddress (EvaluatedTcValue (_to tc)))
       , SSTORE
-      , JUMPTO $ "tc_SKIP" ++ show (_tcId tc) ]
+      , JUMPTO $ "tc_SKIP" ++ show (_to tc) ]
     skipToSetBalanceToZeroIfEvaluatedPayoutIsZero = [
-      JUMPDESTFROM $ "skip_to_set_balance_to_zero" ++ show (_tcId tc)
+      JUMPDESTFROM $ "skip_to_set_balance_to_zero" ++ show (_to tc)
       , POP -- pop evaluated TC-value
-      , JUMPTO $ "tc_SKIP" ++ show (_tcId tc) ]
+      , JUMPTO $ "tc_SKIP" ++ show (_to tc) ]
     skipToMethodEndIfBalanceIsZero = [
-      JUMPDESTFROM $ "skip_to_method_end" ++ show (_tcId tc)
+      JUMPDESTFROM $ "skip_to_method_end" ++ show (_to tc)
       , POP -- pop balance (which has a value of 0)
       , POP -- pop evaluated TC-value
-      , JUMPTO $ "method_end" ++ show (_tcId tc) ]
+      , JUMPTO $ "method_end" ++ show (_to tc) ]
 
     checkIfTCAlreadyEvaluated =
-      [ JUMPDESTFROM $ "begin_tc_evaluation" ++ show (_tcId tc)
-      , push (storageAddress (EvaluatedTcValue (_tcId tc)))
+      [ JUMPDESTFROM $ "begin_tc_evaluation" ++ show (_to tc)
+      , push (storageAddress (EvaluatedTcValue (_to tc)))
       , SLOAD
       , DUP1
       , push 0x0
       , SGT
       , ISZERO
-      , JUMPITO $ "tc_value_already_evaluated" ++ show (_tcId tc)
+      , JUMPITO $ "tc_value_already_evaluated" ++ show (_to tc)
       , POP ]
 
     checkIfCallShouldBeMade =
@@ -724,7 +721,7 @@ executeTransferCallsHH tc =
                                  SUB,
                                  push $ _delay tc,
                                  EVM_GT,
-                                 JUMPITO $ "method_end" ++ show (_tcId tc) ]
+                                 JUMPITO $ "method_end" ++ show (_to tc) ]
 
 
             -- This code can be represented with the following C-like code:
@@ -745,14 +742,14 @@ executeTransferCallsHH tc =
                   , push $ 0x3 * 2 ^ (2 * memExpId) -- bitmask
                   , AND
                   , ISZERO
-                  , JUMPITO $ "method_end" ++ show (_tcId tc) ] -- GOTO YIELD
+                  , JUMPITO $ "method_end" ++ show (_to tc) ] -- GOTO YIELD
 
                 -- if branch is dead set evaluated TC value to zero and jump to tc_skip
                 passAndSkipStatement =
                   [ push $ 2 ^ (2 * memExpId + if branch then 1 else 0) -- bitmask
                   , AND
                   , ISZERO
-                  , JUMPITO $ "set_evaluated_value_to_zero" ++ show (_tcId tc) ]
+                  , JUMPITO $ "set_evaluated_value_to_zero" ++ show (_to tc) ]
                   -- The fall-through case represents the "PASS" case.
               in
                 yieldStatement ++ passAndSkipStatement
@@ -770,36 +767,36 @@ executeTransferCallsHH tc =
         --   >= 0 means that it has been evaluated.
         --
         -- If a TC value has been evaluated, return this value. Otherwise, calculate, store and return it.
-      runExprCompiler (CompileEnv 0 (_tcId tc) 0x44 "amount_exp") (_amount tc)
+      runExprCompiler (CompileEnv 0 (_to tc) 0x44 "amount_exp") (_amount tc)
       ++ [ push (_maxAmount tc)
          , DUP2
          , DUP2
          , SGT -- Security check needed
-         , JUMPITO $ "use_exp_res" ++ show (_tcId tc)
+         , JUMPITO $ "use_exp_res" ++ show (_to tc)
          , SWAP1
-         , JUMPDESTFROM $ "use_exp_res" ++ show (_tcId tc)
+         , JUMPDESTFROM $ "use_exp_res" ++ show (_to tc)
          , POP ] -- Top of stack now has value `a` (evaluated TC value)
 
       -- Store evaluated value in storage
       ++ [ DUP1
-         , push (storageAddress (EvaluatedTcValue (_tcId tc)))
+         , push (storageAddress (EvaluatedTcValue (_to tc)))
          , SSTORE ]
 
-      ++ [ JUMPDESTFROM $ "tc_value_already_evaluated" ++ show (_tcId tc)]
+      ++ [ JUMPDESTFROM $ "tc_value_already_evaluated" ++ show (_to tc)]
 
       -- if evaluated payout value was 0: clear stack first, then jump to tc_skip (set PT balance = 0)
       ++ [ DUP1
          , ISZERO
-         , JUMPITO $ "skip_to_set_balance_to_zero" ++ show (_tcId tc)  ]
+         , JUMPITO $ "skip_to_set_balance_to_zero" ++ show (_to tc)  ]
 
       ++ [ CALLER
-         , PUSH32 $ integer2w256 (getPartyTokenID (_to tc))
+         , PUSH32 $ integer2w256 $ _to tc
          , FUNCALL "getBalance_subroutine" ]  -- pops 2, pushes 1:  balance is on the stack
 
       -- if PT balance is zero: clear stack, then jump to method_end (go to next TC evaluation)
       ++ [ DUP1
          , ISZERO
-         , JUMPITO $ "skip_to_method_end" ++ show (_tcId tc)  ]
+         , JUMPITO $ "skip_to_method_end" ++ show (_to tc)  ]
 
       -- Prepare stack and call transfer subroutine
       ++ [ FUNCALL "safeMul_subroutine" ]
@@ -813,14 +810,14 @@ executeTransferCallsHH tc =
          , JUMPITO "global_throw" ]
 
     setPTBalanceToZero = [
-      JUMPDESTFROM $ "tc_SKIP" ++ show (_tcId tc)
-      , PUSH32 $ integer2w256 (getPartyTokenID (_to tc))
+      JUMPDESTFROM $ "tc_SKIP" ++ show (_to tc)
+      , PUSH32 $ integer2w256 $ _to tc
       , push 0
       , CALLER
       , FUNCALL "setBalance_subroutine" ]
 
     functionEndLabel =
-        [ JUMPDESTFROM $ "method_end" ++ show (_tcId tc) ]
+        [ JUMPDESTFROM $ "method_end" ++ show (_to tc) ]
 
   in
     begin ++
@@ -873,7 +870,7 @@ mint = do
     partyTokenIDs <- reader getPartyTokenIDs
     thing <- concatMapM activateMapElementToTransferFromCall (Map.assocs am)
     requiresPT0 <- reader getRequiresPT0
-    let alsoMintPT0 = if requiresPT0 then (PartyTokenID 0 :) else id
+    let alsoMintPT0 = if requiresPT0 then (0 :) else id
     return $
         -- SA.transferFrom
         thing
@@ -881,8 +878,8 @@ mint = do
         ++ concatMap mintExt (alsoMintPT0 partyTokenIDs)
         ++ emitEvent "Minted" -- TODO: Change to ERC1155 minted event
 
-mintExt :: PartyTokenID -> [EvmOpcode]
-mintExt (PartyTokenID partyTokenID) =
+mintExt :: PartyIndex -> [EvmOpcode]
+mintExt partyTokenID =
   [ push partyTokenID
   , CALLER
   , DUP2
@@ -909,7 +906,7 @@ burn :: Compiler [EvmOpcode]
 burn = do
   partyTokenIDs <- reader getPartyTokenIDs
   requiresPT0 <- reader getRequiresPT0
-  let alsoBurnPT0 = if requiresPT0 then (PartyTokenID 0 :) else id
+  let alsoBurnPT0 = if requiresPT0 then (0 :) else id
   let burnPartyTokensCode = concatMap burnExt (alsoBurnPT0 partyTokenIDs)
 
   pairs <- reader $ Map.assocs . getActivateMap
@@ -927,8 +924,8 @@ burn = do
   return $
     burnPartyTokensCode ++ transferSettlementAssetsCode
 
-burnExt :: PartyTokenID -> [EvmOpcode]
-burnExt (PartyTokenID partyTokenID) =
+burnExt :: PartyIndex -> [EvmOpcode]
+burnExt partyTokenID =
   [ push partyTokenID
   , PUSH1 0x4, CALLDATALOAD -- Gas saving opportunity: CALLDATACOPY
   , FUNCALL "burn_subroutine"

--- a/src/EvmCompilerSubroutines.hs
+++ b/src/EvmCompilerSubroutines.hs
@@ -24,7 +24,7 @@
 
 module EvmCompilerSubroutines
   ( subroutines
-  , transferCallToSettlementAsset
+  , partyTokenIdToSettlementAssetId
   ) where
 
 import EvmCompilerHelper
@@ -416,19 +416,19 @@ safeSubSubroutine =
   ]
 
 -- | Convert a list of 'TransferCall' to a subroutine that converts
--- a 'TransferCallId' into a 'SettlementAssetId'.
+-- a 'PartyTokenId' (ptid) to a 'SettlementAssetId'.
 --
--- Stack before FUNSTART: [ return address, tcId, ... ]
--- Stack after FUNSTART: [ tcId, return address, ... ]
+-- Stack before FUNSTART: [ return address, ptid, ... ]
+-- Stack after FUNSTART: [ ptid, return address, ... ]
 -- Stack after returning: [ saId, ... ]
 --
-transferCallToSettlementAsset :: [TransferCall] -> [EvmOpcode]
-transferCallToSettlementAsset transferCalls =
-  [ FUNSTART "transferCallToSettlementAsset_subroutine" 1 ]
+partyTokenIdToSettlementAssetId :: [TransferCall] -> [EvmOpcode]
+partyTokenIdToSettlementAssetId transferCalls =
+  [ FUNSTART "partyTokenIdToSettlementAssetId_subroutine" 1 ]
   ++ concatMap derp transferCalls
   ++ [ JUMPITO "global_throw" -- code path should be unreachable
-     , JUMPDESTFROM "transferCallToSettlementAsset_result"
-       -- Stack = [ _saId, inputTcId, RA ]
+     , JUMPDESTFROM "partyTokenIdToSettlementAssetId_result"
+       -- Stack = [ _saId, inputPtId, RA ]
      , SWAP1
      , POP
        -- Stack = [ _saId, RA ]
@@ -437,15 +437,15 @@ transferCallToSettlementAsset transferCalls =
   where
     derp :: TransferCall -> [EvmOpcode]
     derp TransferCall{..} =
-      [ -- Stack = [ inputTcId, RA ]
+      [ -- Stack = [ inputPtId, RA ]
         push (getSettlementAssetId _saId)
-        -- Stack = [ _saId, inputTcId, RA ]
+        -- Stack = [ _saId, inputPtId, RA ]
       , DUP2
-      , push _tcId
+      , push _to
       , EVM_EQ
-        -- Stack = [ _tcId == inputTcId, _saId, inputTcId, RA ]
-      , JUMPITO "transferCallToSettlementAsset_result"
-        -- Stack = [ _saId, inputTcId, RA ]
+        -- Stack = [ _to == inputPtId, _saId, inputTcId, RA ]
+      , JUMPITO "partyTokenIdToSettlementAssetId_result"
+        -- Stack = [ _saId, inputPtId, RA ]
       , POP
-        -- Stack = [ inputTcId, RA ]
+        -- Stack = [ inputPtId, RA ]
       ]

--- a/src/EvmCompilerSubroutines.hs
+++ b/src/EvmCompilerSubroutines.hs
@@ -24,7 +24,7 @@
 
 module EvmCompilerSubroutines
   ( subroutines
-  , partyTokenIdToSettlementAssetId
+  , partyIndexToSettlementAssetId
   ) where
 
 import EvmCompilerHelper
@@ -416,18 +416,18 @@ safeSubSubroutine =
   ]
 
 -- | Convert a list of 'TransferCall' to a subroutine that converts
--- a 'PartyTokenId' (ptid) to a 'SettlementAssetId'.
+-- a 'PartyIndex' to a 'SettlementAssetId'.
 --
 -- Stack before FUNSTART: [ return address, ptid, ... ]
 -- Stack after FUNSTART: [ ptid, return address, ... ]
 -- Stack after returning: [ saId, ... ]
 --
-partyTokenIdToSettlementAssetId :: [TransferCall] -> [EvmOpcode]
-partyTokenIdToSettlementAssetId transferCalls =
-  [ FUNSTART "partyTokenIdToSettlementAssetId_subroutine" 1 ]
+partyIndexToSettlementAssetId :: [TransferCall] -> [EvmOpcode]
+partyIndexToSettlementAssetId transferCalls =
+  [ FUNSTART "partyIndexToSettlementAssetId_subroutine" 1 ]
   ++ concatMap derp transferCalls
   ++ [ JUMPITO "global_throw" -- code path should be unreachable
-     , JUMPDESTFROM "partyTokenIdToSettlementAssetId_result"
+     , JUMPDESTFROM "partyIndexToSettlementAssetId_result"
        -- Stack = [ _saId, inputPtId, RA ]
      , SWAP1
      , POP
@@ -444,7 +444,7 @@ partyTokenIdToSettlementAssetId transferCalls =
       , push _to
       , EVM_EQ
         -- Stack = [ _to == inputPtId, _saId, inputTcId, RA ]
-      , JUMPITO "partyTokenIdToSettlementAssetId_result"
+      , JUMPITO "partyIndexToSettlementAssetId_result"
         -- Stack = [ _saId, inputPtId, RA ]
       , POP
         -- Stack = [ inputPtId, RA ]

--- a/src/IntermediateCompiler.hs
+++ b/src/IntermediateCompiler.hs
@@ -119,7 +119,7 @@ intermediateCompileM (Transfer saAddress to) = do
                                   , _delay         = delayTerm
                                   , _saAddress     = saAddress
                                   , _saId          = settlementAssetId
-                                  , _to            = getPartyTokenID to
+                                  , _to            = to
                                   , _memExpPath    = memExpPath
                                   }
 

--- a/src/IntermediateCompiler.hs
+++ b/src/IntermediateCompiler.hs
@@ -44,7 +44,6 @@ data ScopeEnv =
 
 data GlobalEnv = GlobalEnv
   { _memExpId       :: Maybe MemExpId
-  , _transferCallId :: TransferCallId
   , _encounteredSettlementAssets :: [(Address, SettlementAssetId)]
   }
 
@@ -62,7 +61,6 @@ initialScope = ScopeEnv { _maxFactor   = 1
 initialGlobal :: GlobalEnv
 initialGlobal = GlobalEnv
   { _memExpId       = Nothing
-  , _transferCallId = 0
   , _encounteredSettlementAssets = []
   }
 
@@ -93,12 +91,6 @@ newMemExpId = do
     increment (Just memExpId) = memExpId + 1
     increment _         = 0
 
-newTransferCallId :: ICompiler TransferCallId
-newTransferCallId = do
-  tcId <- gets _transferCallId
-  modify $ \env -> env { _transferCallId = tcId + 1 }
-  return tcId
-
 toSeconds :: Time -> Integer
 toSeconds t = case t of
   Now       -> 0
@@ -121,16 +113,14 @@ intermediateCompileOptimize = foldExprs . intermediateCompile
 intermediateCompileM :: Contract -> ICompiler IntermediateContract
 intermediateCompileM (Transfer saAddress to) = do
   ScopeEnv maxFactor scaleFactor delayTerm memExpPath <- ask
-  transferCallId <- newTransferCallId
   settlementAssetId <- getSettlemenAssetId saAddress
   let transferCall = TransferCall { _maxAmount     = maxFactor
                                   , _amount        = scaleFactor (Lit (IntVal 1))
                                   , _delay         = delayTerm
                                   , _saAddress     = saAddress
                                   , _saId          = settlementAssetId
-                                  , _to            = to
+                                  , _to            = getPartyTokenID to
                                   , _memExpPath    = memExpPath
-                                  , _tcId          = transferCallId
                                   }
 
   let activateMap = Map.fromList [(settlementAssetId, (maxFactor, saAddress))]

--- a/src/IntermediateLanguageDefinition.hs
+++ b/src/IntermediateLanguageDefinition.hs
@@ -28,8 +28,6 @@ import SwordLanguageDefinition
 
 import qualified Data.Map.Strict as Map
 
-type PartyIndex = Integer
-
 type MemExpId = Integer
 type Branch = Bool
 type MemExpPath = [(MemExpId, Branch)]
@@ -51,12 +49,12 @@ data TransferCall =
                   , _memExpPath   :: MemExpPath
                   } deriving (Show, Eq)
 
-getPartyTokenIDs :: IntermediateContract -> [PartyIndex]
-getPartyTokenIDs IntermediateContract{..} =
+getPartyIndices :: IntermediateContract -> [PartyIndex]
+getPartyIndices IntermediateContract{..} =
   map _to getTransferCalls
 
-getMaxPartyTokenId :: IntermediateContract -> PartyIndex
-getMaxPartyTokenId = maximum . getPartyTokenIDs
+getMaxPartyIndex :: IntermediateContract -> PartyIndex
+getMaxPartyIndex = maximum . getPartyIndices
 
 -- DEVNOTE:
 -- We start by attempting to implement the evaluation of IMemExp values.

--- a/src/IntermediateLanguageDefinition.hs
+++ b/src/IntermediateLanguageDefinition.hs
@@ -29,10 +29,8 @@ import SwordLanguageDefinition
 import qualified Data.Map.Strict as Map
 
 type PartyIndex = Integer
-type PartyIdentifier = Integer
 
 type MemExpId = Integer
-type TransferCallId = Integer
 type Branch = Bool
 type MemExpPath = [(MemExpId, Branch)]
 
@@ -49,21 +47,16 @@ data TransferCall =
                   , _delay        :: Integer
                   , _saAddress    :: Address -- SA
                   , _saId         :: SettlementAssetId
-                  , _to           :: PartyTokenID
+                  , _to           :: PartyIndex
                   , _memExpPath   :: MemExpPath
-                  , _tcId         :: TransferCallId
                   } deriving (Show, Eq)
 
-getPartyTokenIDs :: IntermediateContract -> [PartyTokenID]
+getPartyTokenIDs :: IntermediateContract -> [PartyIndex]
 getPartyTokenIDs IntermediateContract{..} =
   map _to getTransferCalls
 
-getTransferCallIDs :: IntermediateContract -> [TransferCallId]
-getTransferCallIDs IntermediateContract{..} =
-  map _tcId getTransferCalls
-
-getMaxTcId :: IntermediateContract -> TransferCallId
-getMaxTcId = maximum . getTransferCallIDs
+getMaxPartyTokenId :: IntermediateContract -> PartyIndex
+getMaxPartyTokenId = maximum . getPartyTokenIDs
 
 -- DEVNOTE:
 -- We start by attempting to implement the evaluation of IMemExp values.

--- a/src/SwordLanguageDefinition.hs
+++ b/src/SwordLanguageDefinition.hs
@@ -23,7 +23,7 @@
 module SwordLanguageDefinition where
 
 data Contract = Transfer { tokenAddress_ :: Address,
-                           to_           :: PartyTokenID
+                           to_           :: PartyIndex
                          }
               | Scale { maxFactor_   :: Integer,
                         scaleFactor_ :: Expr,
@@ -82,10 +82,7 @@ data ObservableType = OBool | OInteger deriving (Show, Eq)
 
 type TokenSymbol = String
 type Address = String
-
--- Party Token IDs are ERC1155 index values
-newtype PartyTokenID = PartyTokenID { getPartyTokenID :: Integer }
-  deriving (Eq, Ord, Show)
+type PartyIndex = Integer
 
 getSubExps :: Expr -> [Expr]
 getSubExps e = case e of

--- a/src/SwordParser.hs
+++ b/src/SwordParser.hs
@@ -67,7 +67,7 @@ transferParser = do
   parens $ do
     ta <- getAddress
     symbol ","
-    to <- PartyTokenID <$> getIntBasic
+    to <- getIntBasic
     return $ Transfer ta to
 
 scaleParser :: Parser Contract

--- a/test/IntermediateCompilerTest.hs
+++ b/test/IntermediateCompilerTest.hs
@@ -71,11 +71,11 @@ timeTranslationIMemExpTest = do
         transfers
           = [TransferCall{_maxAmount = 1, _amount = Lit (IntVal 1),
                           _delay = 120, _saAddress = tokAddr,
-                          _to = PartyTokenID 1, _memExpPath = [(0, True)]},
+                          _to = 1, _memExpPath = [(0, True)]},
              TransferCall{_maxAmount = 2,
                           _amount = MultExp (Lit (IntVal 1)) (Lit (IntVal 2)),
                           _delay = 120, _saAddress = tokAddr,
-                          _to = PartyTokenID 1, _memExpPath = [(0, False)]}]
+                          _to = 2, _memExpPath = [(0, False)]}]
 
         memExps = [IMemExp 120 240 0 (Lit (Observable OBool obsAddr "0"))]
         activateMap = Map.fromList [(SettlementAssetId 0, (2, tokAddr))]
@@ -102,7 +102,7 @@ zeroContractCodeTest = do
 
         transfers
           = [TransferCall{_maxAmount = 1, _amount = Lit (IntVal 1), _delay = 0,
-                          _saAddress = tokAddr, _to = PartyTokenID 1,
+                          _saAddress = tokAddr, _to = 1,
                           _memExpPath = [(0, True)]}]
 
         memExps

--- a/test/SwordParserTest.hs
+++ b/test/SwordParserTest.hs
@@ -105,7 +105,7 @@ parser_unittest0 =
     src = "transfer(0x123456789012345678901234567890123456789a, 1)"
     ast :: Contract
     ast =  Transfer { tokenAddress_ = "0x123456789012345678901234567890123456789a"
-                    , to_           = PartyTokenID 1
+                    , to_           = 1
                     }
 
 canonical_iw_source :: String

--- a/test/TypeCheckerTest.hs
+++ b/test/TypeCheckerTest.hs
@@ -51,7 +51,7 @@ tests = do
 transferContract :: Contract
 transferContract = Transfer {
     tokenAddress_ = "0x123456789012345678901234567890123456789a",
-    to_           = PartyTokenID 1
+    to_           = 1
 }
 
 scaleContract :: Integer -> Expr -> Contract -> Contract


### PR DESCRIPTION
This TCID value is not needed as all transfer calls are already uniquely
identified by their party token (which currently is held in the _to
parameter of the intermediate contract). This code removes this ID from
the code base. The only non-trivial change is to the expression
`subtractEvaluatedPTValuesFromSaAmounts` where a calculation of the
payback streams to the PT0 holder is calculated. This loops over all
party token IDs from the max value to 1 and calculates the how much
should be paid back to PT0. Previously the condition to check if the
loop was done was tcid <= 0; now the condition is ptid == 0, this saves
three instructions. This function also necessitated that a subroutine
was changed, it previously mapped from map from TCID to SAID but now
maps from PTID to SAID.

This addresses #39.

This commit has been successfully tested against the test set in
`geth_tools`.